### PR TITLE
jaf: fix fprintf argument

### DIFF
--- a/src/core/jaf/error.c
+++ b/src/core/jaf/error.c
@@ -171,7 +171,7 @@ void jaf_print_expression(FILE *out, struct jaf_expression *expr)
 		fputc('(', out);
 		jaf_print_expression(out, expr->lhs);
 		fputc(' ', out);
-		fprintf(out, jaf_op_to_string(expr->op));
+		fprintf(out, "%s", jaf_op_to_string(expr->op));
 		fputc(' ', out);
 		jaf_print_expression(out, expr->rhs);
 		fputc(')', out);


### PR DESCRIPTION
Fixes compile error with -Werror=format-security enabled:

```
../src/core/jaf/error.c: In function 'jaf_print_expression': ../src/core/jaf/error.c:174:17: error: format not a string literal and no format arguments [-Werror=format-security]
  174 |                 fprintf(out, jaf_op_to_string(expr->op));
      |                 ^~~~~~~
```

This is already done in the other 2 instances where `jaf_op_to_string` is called & subsequently `fprintf`'d:

https://github.com/nunuhara/alice-tools/blob/5aa59f45a41b19914f4fe2c55a3f1ccb706d98a7/src/core/jaf/error.c#L163-L165