### PR TITLE
ain dump: add option to generate HLL stubs for xsystem4

### DIFF
--- a/include/alice/ain.h
+++ b/include/alice/ain.h
@@ -87,6 +87,7 @@ void ain_dump_global(struct port *port, struct ain *ain, int i);
 void ain_dump_structure(struct port *port, struct ain *ain, int i);
 void ain_dump_text(struct port *port, struct ain *ain);
 void ain_dump_library(struct port *port, struct ain *ain, int lib);
+void ain_dump_library_stub(struct port *port, struct ain_library *lib);
 void ain_dump_functype(struct port *port, struct ain *ain, int i, bool delegate);
 void ain_dump_enum(struct port *port, struct ain *ain, int i);
 


### PR DESCRIPTION
`alice ain dump --hll-stubs ...` will generate .c files that can be copied into xsystem4's `src/hll` directory.

If `AUTHOR` environment variable is set, it is used in the license header of generated files.

Recommended usage:
```sh
AUTHOR="`git config --get user.name` <`git config --get user.email`>" \
    alice ain dump --hll-stubs *.ain
```