### PR TITLE
Convert all command line arguments from UTF-16 to UTF-8 on Windows

### DIFF
--- a/include/alice.h
+++ b/include/alice.h
@@ -52,7 +52,7 @@ char *conv_utf8_input(const char *str);
 char *conv_utf8_input_len(const char *str, size_t len);
 struct string *string_conv_utf8_input(const char *str, size_t len);
 
-char *conv_cmdline_utf8(const char *str);
+void conv_cmdline_utf8(int *pargc, char ***pargv);
 
 struct stat;
 

--- a/src/cli/acx_build.c
+++ b/src/cli/acx_build.c
@@ -59,11 +59,7 @@ int command_acx_build(int argc, char *argv[])
 	current_file_name = (const char**)&argv[0];
 
 	FILE *out = alice_open_output_file(output_file);
-
-	char *input_file = conv_cmdline_utf8(argv[0]);
-	struct acx *acx = acx_parse(input_file);
-	free(input_file);
-
+	struct acx *acx = acx_parse(argv[0]);
 	acx_write(out, acx);
 	acx_free(acx);
 	fclose(out);

--- a/src/cli/acx_dump.c
+++ b/src/cli/acx_dump.c
@@ -56,10 +56,7 @@ int command_acx_dump(int argc, char *argv[])
 	int error = ACX_SUCCESS;
 	FILE *out = alice_open_output_file(output_file);
 
-	char *input_file = conv_cmdline_utf8(argv[0]);
-	struct acx *acx = acx_load(input_file, &error);
-	free(input_file);
-
+	struct acx *acx = acx_load(argv[0], &error);
 	if (error == ACX_ERROR_FILE) {
 		ALICE_ERROR("Failed to load .acx file \"%s\": %s", argv[0], strerror(errno));
 	} else if (error != ACX_SUCCESS) {

--- a/src/cli/ain_compare.c
+++ b/src/cli/ain_compare.c
@@ -618,13 +618,9 @@ int command_ain_compare(int argc, char *argv[])
 		USAGE_ERROR(&cmd_ain_compare, "Wrong number of arguments");
 	}
 
-	char *path_a = conv_cmdline_utf8(argv[0]);
-	char *path_b = conv_cmdline_utf8(argv[1]);
-	if (!(a = ain_open(path_a, &err)) || !(b = ain_open(path_b, &err))) {
+	if (!(a = ain_open(argv[0], &err)) || !(b = ain_open(argv[1], &err))) {
 		ALICE_ERROR("Failed to open ain file: %s", ain_strerror(err));
 	}
-	free(path_a);
-	free(path_b);
 
 	ain_compare(a, b);
 	ain_free(a);

--- a/src/cli/ain_dump.c
+++ b/src/cli/ain_dump.c
@@ -351,7 +351,7 @@ int command_ain_dump(int argc, char *argv[])
 			dump_targets[dump_ptr++] = LOPT_FUNCTIONS;
 			break;
 		case LOPT_FUNCTION:
-			dump_args[dump_ptr] = conv_cmdline_utf8(optarg);
+			dump_args[dump_ptr] = optarg;
 			dump_targets[dump_ptr++] = LOPT_FUNCTION;
 			break;
 		case 'g':
@@ -443,12 +443,10 @@ int command_ain_dump(int argc, char *argv[])
 		return 0;
 	}
 
-	char *input_file = conv_cmdline_utf8(argv[0]);
-	if (!(ain = ain_open(input_file, &err))) {
+	if (!(ain = ain_open(argv[0], &err))) {
 		ALICE_ERROR("Failed to open ain file: %s\n", ain_strerror(err));
 		return 1;
 	}
-	free(input_file);
 
 	ain_init_member_functions(ain, conv_utf8);
 
@@ -467,7 +465,7 @@ int command_ain_dump(int argc, char *argv[])
 		case LOPT_TEXT:           ain_dump_text(&port, ain); break;
 		case LOPT_AIN_VERSION:    ain_dump_version(&port, ain); break;
 		case LOPT_FUNCTIONS:      ain_dump_functions(&port, ain); break;
-		case LOPT_FUNCTION:       ain_disassemble_function(&port, ain, dump_args[i], flags); free(dump_args[i]); break;
+		case LOPT_FUNCTION:       ain_disassemble_function(&port, ain, dump_args[i], flags); break;
 		case LOPT_GLOBALS:        ain_dump_globals(&port, ain); break;
 		case LOPT_STRUCTURES:     ain_dump_structures(&port, ain); break;
 		case LOPT_MESSAGES:       ain_dump_messages(&port, ain); break;

--- a/src/cli/ain_edit.c
+++ b/src/cli/ain_edit.c
@@ -93,7 +93,7 @@ int command_ain_edit(int argc, char *argv[])
 		switch (c) {
 		case 'p':
 		case LOPT_PROJECT:
-			project_file = conv_cmdline_utf8(optarg);
+			project_file = optarg;
 			break;
 		case 'c':
 		case LOPT_CODE:
@@ -151,7 +151,6 @@ int command_ain_edit(int argc, char *argv[])
 			WARNING("Input files specified on the command line are ignored in --project mode");
 		}
 		pje_build(project_file);
-		free(project_file);
 		return 0;
 	}
 
@@ -162,11 +161,9 @@ int command_ain_edit(int argc, char *argv[])
 	if (!argc) {
 		ain = ain_new(major_version, minor_version);
 	} else {
-		char *input_file = conv_cmdline_utf8(argv[0]);
-		if (!(ain = ain_open(input_file, &err))) {
+		if (!(ain = ain_open(argv[0], &err))) {
 			ALICE_ERROR("Failed to open ain file: %s", ain_strerror(err));
 		}
-		free(input_file);
 	}
 	ain_init_member_functions(ain, conv_output_utf8);
 

--- a/src/cli/alice.c
+++ b/src/cli/alice.c
@@ -339,6 +339,7 @@ static int process_command(struct command *cmd, int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
+	conv_cmdline_utf8(&argc, &argv);
 	if (argc < 2) {
 		print_usage(&cmd_alice);
 		exit(0);

--- a/src/cli/cg_convert.c
+++ b/src/cli/cg_convert.c
@@ -72,25 +72,22 @@ int command_cg_convert(int argc, char *argv[])
 	if (argc < 1 || argc > 2)
 		USAGE_ERROR(&cmd_cg_convert, "Wrong number of arguments");
 
-	char *input_file = conv_cmdline_utf8(argv[0]);
 	if (argc == 1) {
 		if (output_format == ALCG_UNKNOWN)
 			ALICE_ERROR("No output format specified");
-		output_file = replace_extension(input_file, cg_file_extension(output_format));
+		output_file = replace_extension(argv[0], cg_file_extension(output_format));
 	} else if (argc == 2) {
-		char *output_cstr = conv_cmdline_utf8(argv[1]);
 		if (output_format == ALCG_UNKNOWN)
-			output_format = parse_cg_format(file_extension(output_cstr));
-		output_file = cstr_to_string(output_cstr);
-		free(output_cstr);
+			output_format = parse_cg_format(file_extension(argv[1]));
+		output_file = cstr_to_string(argv[1]);
 	} else {
 		USAGE_ERROR(&cmd_cg_convert, "Wrong number of arguments");
 	}
 
 	// open input CG
-	struct cg *in = cg_load_file(input_file);
+	struct cg *in = cg_load_file(argv[0]);
 	if (!in)
-		ALICE_ERROR("Failed to read input CG: %s", input_file);
+		ALICE_ERROR("Failed to read input CG: %s", argv[0]);
 
 	// encode/write output CG
 	FILE *out = checked_fopen(output_file->text, "wb");
@@ -100,7 +97,6 @@ int command_cg_convert(int argc, char *argv[])
 	cg_free(in);
 	fclose(out);
 	free_string(output_file);
-	free(input_file);
 	return 0;
 }
 

--- a/src/cli/cg_thumbnail.c
+++ b/src/cli/cg_thumbnail.c
@@ -44,7 +44,7 @@ static int command_cg_thumbnail(int argc, char *argv[])
 		switch (c) {
 		case 'o':
 		case LOPT_OUTPUT:
-			output_file = conv_cmdline_utf8(optarg);
+			output_file = optarg;
 			break;
 		case 's':
 		case LOPT_SIZE:
@@ -61,10 +61,9 @@ static int command_cg_thumbnail(int argc, char *argv[])
 	if (size < 16 || size > 4096)
 		USAGE_ERROR(&cmd_cg_thumbnail, "Size out of range (allowed range is [16-4096])");
 
-	char *input_file = conv_cmdline_utf8(argv[0]);
-	struct cg *in = cg_load_file(input_file);
+	struct cg *in = cg_load_file(argv[0]);
 	if (!in)
-		ALICE_ERROR("Failed to load input CG: %s", input_file);
+		ALICE_ERROR("Failed to load input CG: %s", argv[0]);
 
 	// scale/write output CG
 	float scale = (float)size / (float)max(in->metrics.w, in->metrics.h);
@@ -77,8 +76,6 @@ static int command_cg_thumbnail(int argc, char *argv[])
 	cg_free(in);
 	cg_free(out);
 	fclose(f);
-	free(input_file);
-	free(output_file);
 	return 0;
 }
 

--- a/src/cli/ex_build.c
+++ b/src/cli/ex_build.c
@@ -68,10 +68,7 @@ int command_ex_build(int argc, char *argv[])
 
 	FILE *out = alice_open_output_file(output_file);
 
-	char *input_file = conv_cmdline_utf8(argv[0]);
-	struct ex *ex = ex_parse_file(input_file);
-	free(input_file);
-
+	struct ex *ex = ex_parse_file(argv[0]);
 	if (!ex) {
 		ALICE_ERROR("failed to parse .txtex file: '%s'", argv[0]);
 	}

--- a/src/cli/ex_dump.c
+++ b/src/cli/ex_dump.c
@@ -84,10 +84,7 @@ int command_ex_dump(int argc, char *argv[])
 		return 0;
 	}
 
-	char *input_file = conv_cmdline_utf8(argv[0]);
-	struct ex *ex = ex_read_file(input_file);
-	free(input_file);
-
+	struct ex *ex = ex_read_file(argv[0]);
 	if (!ex)
 		ALICE_ERROR("ex_read_file(\"%s\") failed", argv[0]);
 

--- a/src/cli/ex_edit.c
+++ b/src/cli/ex_edit.c
@@ -73,18 +73,12 @@ static int command_ex_edit(int argc, char *argv[]) {
 
 	FILE *out = alice_open_output_file(output_file);
 
-	char *base_file = conv_cmdline_utf8(argv[0]);
-	struct ex *base = ex_read_file(base_file);
-	free(base_file);
-
+	struct ex *base = ex_read_file(argv[0]);
 	if (!base) {
 		ALICE_ERROR("failed to read .ex file: %s", argv[0]);
 	}
 
-	char *edit_file = conv_cmdline_utf8(argv[1]);
-	struct ex *edit = ex_parse_file(edit_file);
-	free(edit_file);
-
+	struct ex *edit = ex_parse_file(argv[1]);
 	if (!edit) {
 		ALICE_ERROR("failed to parse .txtex file: %s", argv[1]);
 	}

--- a/src/cli/flat_build.c
+++ b/src/cli/flat_build.c
@@ -57,10 +57,7 @@ int command_flat_build(int argc, char *argv[])
 	}
 
 	// build flat object from manifest
-	char *input_file = conv_cmdline_utf8(argv[0]);
-	struct flat_archive *flat = flat_build(input_file, &mf_output_file);
-	free(input_file);
-
+	struct flat_archive *flat = flat_build(argv[0], &mf_output_file);
 	if (!output_file) {
 		if (mf_output_file) {
 			struct string *dir = cstr_to_string(path_dirname(argv[0]));

--- a/src/cli/flat_extract.c
+++ b/src/cli/flat_extract.c
@@ -69,10 +69,7 @@ int command_flat_extract(int argc, char *argv[])
 	// open .flat file
 	struct flat_archive *flat;
 	int error;
-	char *input_file = conv_cmdline_utf8(argv[0]);
-	flat = flat_open_file(input_file, 0, &error);
-	free(input_file);
-
+	flat = flat_open_file(argv[0], 0, &error);
 	if (!flat) {
 		ALICE_ERROR("Opening archive: %s", archive_strerror(error));
 	}

--- a/src/cli/fnl_dump.c
+++ b/src/cli/fnl_dump.c
@@ -110,10 +110,7 @@ int command_fnl_dump(int argc, char *argv[])
 		USAGE_ERROR(&cmd_fnl_dump, "Wrong number of arguments");
 	}
 
-	char *input_file = conv_cmdline_utf8(argv[0]);
-	struct fnl *fnl = fnl_open(input_file);
-	free(input_file);
-
+	struct fnl *fnl = fnl_open(argv[0]);
 	if (!fnl)
 		ALICE_ERROR("fnl_open failed");
 

--- a/src/cli/project_build.c
+++ b/src/cli/project_build.c
@@ -41,9 +41,7 @@ static int command_project_build(int argc, char *argv[])
 	if (argc != 1)
 		USAGE_ERROR(&cmd_project_build, "Wrong number of arguments");
 
-	char *input_file = conv_cmdline_utf8(argv[0]);
-	pje_build(input_file);
-	free(input_file);
+	pje_build(argv[0]);
 	return 0;
 }
 


### PR DESCRIPTION
Instead of converting to UTF-8 individually in subcommands, reset all pointers in `argv` to UTF-8 strings at startup.

This also allows characters that are not in the current system codepage to be used on the command line.

Note that SDL2 does this under the hood so in xsystem4 we can assume that `argv` is all in UTF-8.
https://github.com/libsdl-org/SDL/blob/SDL2/src/main/windows/SDL_windows_main.c
