### PR TITLE
Replace all fopen() calls with file_open_utf8()

### DIFF
--- a/src/cli/alice.c
+++ b/src/cli/alice.c
@@ -21,6 +21,7 @@
 #include <fcntl.h>
 #include <iconv.h>
 #include "system4.h"
+#include "system4/file.h"
 #include "alice.h"
 #include "cli.h"
 
@@ -173,7 +174,7 @@ FILE *alice_open_output_file(const char *path)
 #endif
 		return stdout;
 	}
-	FILE *out = fopen(path, "wb");
+	FILE *out = file_open_utf8(path, "wb");
 	if (!out)
 		ALICE_ERROR("fopen: %s", strerror(errno));
 	return out;

--- a/src/cli/fnl_dump.c
+++ b/src/cli/fnl_dump.c
@@ -132,7 +132,7 @@ int command_fnl_dump(int argc, char *argv[])
 
 				sprintf(path, "%s/font_%u/%upx/glyph_%u.png", output_dir, (unsigned)font,
 					(unsigned)font_face->height, (unsigned)g);
-				FILE *f = fopen(path, "wb");
+				FILE *f = file_open_utf8(path, "wb");
 				if (!f) {
 					ERROR("fopen failed: %s", strerror(errno));
 				}

--- a/src/core/ain/asm.c
+++ b/src/core/ain/asm.c
@@ -22,6 +22,7 @@
 #include <errno.h>
 #include "system4.h"
 #include "system4/ain.h"
+#include "system4/file.h"
 #include "system4/hashtable.h"
 #include "system4/instructions.h"
 #include "system4/string.h"
@@ -979,7 +980,7 @@ static parse_instruction_list *jam_parse(const char *filename, uint32_t instr_pt
 	if (!strcmp(filename, "-"))
 		asm_in = stdin;
 	else
-		asm_in = fopen(filename, "r");
+		asm_in = file_open_utf8(filename, "r");
 	if (!asm_in)
 		ERROR("Opening input file '%s': %s", filename, strerror(errno));
 

--- a/src/core/ain/json_read.c
+++ b/src/core/ain/json_read.c
@@ -22,6 +22,7 @@
 #include "cJSON.h"
 #include "system4.h"
 #include "system4/ain.h"
+#include "system4/file.h"
 
 static bool cJSON_GetObjectBool(const cJSON * const o, const char * const name, bool def)
 {
@@ -525,7 +526,7 @@ void ain_read_json(const char *filename, struct ain *ain)
 	long len;
 	char *buf;
 
-	if (!(f = fopen(filename, "r")))
+	if (!(f = file_open_utf8(filename, "rb")))
 		ERROR("Failed to open '%s': %s", filename, strerror(errno));
 
 	fseek(f, 0, SEEK_END);

--- a/src/core/ain/repack.c
+++ b/src/core/ain/repack.c
@@ -22,6 +22,7 @@
 #include <zlib.h>
 #include "system4.h"
 #include "system4/ain.h"
+#include "system4/file.h"
 #include "system4/string.h"
 
 struct ain_buffer {
@@ -451,7 +452,7 @@ void ain_write(const char *filename, struct ain *ain)
 	else
 		buf = ain_compress(buf, &len);
 
-	FILE *out = fopen(filename, "wb");
+	FILE *out = file_open_utf8(filename, "wb");
 	if (!out)
 		ERROR("Failed to open '%s': %s", filename, strerror(errno));
 	if (fwrite(buf, len, 1, out) != 1)

--- a/src/core/ain/text.c
+++ b/src/core/ain/text.c
@@ -20,6 +20,7 @@
 #include "alice.h"
 #include "system4.h"
 #include "system4/ain.h"
+#include "system4/file.h"
 #include "system4/string.h"
 #include "text_parser.tab.h"
 
@@ -36,7 +37,7 @@ void ain_read_text(const char *filename, struct ain *ain)
 	if (!strcmp(filename, "-"))
 		text_in = stdin;
 	else
-		text_in = fopen(filename, "r");
+		text_in = file_open_utf8(filename, "r");
 	if (!text_in)
 		ERROR("Opening input file '%s': %s", filename, strerror(errno));
 	text_parse();

--- a/src/core/ar/manifest_parser.y
+++ b/src/core/ar/manifest_parser.y
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <errno.h>
 #include "system4.h"
+#include "system4/file.h"
 #include "system4/string.h"
 #include "alice.h"
 #include "alice/ar.h"
@@ -38,7 +39,7 @@ struct ar_manifest *ar_parse_manifest(const char *path)
     if (!strcmp(path, "-"))
 	ar_mf_in = stdin;
     else
-	ar_mf_in = fopen(path, "rb");
+	ar_mf_in = file_open_utf8(path, "rb");
     if (!ar_mf_in)
 	ALICE_ERROR("Opening input file '%s': %s", path, strerror(errno));
     ar_mf_parse();

--- a/src/core/jaf/jaf_parser.y
+++ b/src/core/jaf/jaf_parser.y
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include "system4.h"
 #include "system4/ain.h"
+#include "system4/file.h"
 #include "system4/string.h"
 #include "alice.h"
 #include "alice/jaf.h"
@@ -47,7 +48,7 @@ static FILE *open_jaf_file(const char *file)
 {
     if (!strcmp(file, "-"))
 	return stdin;
-    FILE *f = fopen(file, "rb");
+    FILE *f = file_open_utf8(file, "rb");
     if (!f)
 	ERROR("Opening input file '%s': %s", file, strerror(errno));
     return f;


### PR DESCRIPTION
Since all command line arguments are now converted to UTF-8 on Windows, raw `fopen()` should no longer be used.