### PR TITLE
ain edit: Fix "Non-array in array-type slot" error when reading JSON

### DIFF
--- a/src/core/ain/json_read.c
+++ b/src/core/ain/json_read.c
@@ -96,7 +96,9 @@ static void read_type_declaration(cJSON *decl, struct ain_type *dst)
 	_read_type_declaration(decl, dst);
 	if (size == 4) {
 		int i;
-		cJSON *v, *a = cJSON_GetArrayItem(decl, 4);
+		cJSON *v, *a = cJSON_GetArrayItem(decl, 3);
+		if (cJSON_IsNull(a))
+			return;
 		if (!cJSON_IsArray(a))
 			ERROR("Non-array in array-type slot");
 		if (cJSON_GetArraySize(a) == 0)


### PR DESCRIPTION
The index of the array-type slot in type declaration is 3, and its value can be null.